### PR TITLE
fix: fix mods list being enabled/disabled

### DIFF
--- a/stalker-gamma-gui/Views/MainWindow.axaml
+++ b/stalker-gamma-gui/Views/MainWindow.axaml
@@ -24,7 +24,7 @@
             <TabItem x:Name="MainTabItem" FontSize="16" Header="Main" IsEnabled="{Binding !IsBusyService.IsBusy}">
                 <tabs:MainTab DataContext="{Binding MainTabVm}" />
             </TabItem>
-            <TabItem x:Name="ModsListItem" FontSize="16" Header="Mods List">
+            <TabItem x:Name="ModsListItem" FontSize="16" Header="Mods List" IsEnabled="{Binding !IsBusyService.IsBusy}">
                 <tabs:ModListTab DataContext="{Binding ModListTabVm}" />
             </TabItem>
             <TabItem x:Name="ModsTabItem" FontSize="16" Header="ModDB Updates" IsEnabled="{Binding !IsBusyService.IsBusy}">


### PR DESCRIPTION
fix mods list being able to be clicked to while an update is  happening, and not being able to click back because the other tabs are blocked